### PR TITLE
Update di dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express dependency injection"
   ],
   "dependencies": {
-    "di": "^2.0.0-pre-9"
+    "di": "^2.0.0-pre-14"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
The pre-9 version had traceur as a dependency pointed to a github branch, which causes issues in quite a few environments.

In -pre-14 (most current release) this is fixed to traceur 0.0.33.
